### PR TITLE
Implement the release! interface.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [postgresql "8.4-702.jdbc4"]
-                 [org.clojure/java.jdbc "0.2.3"]])
+                 [org.clojure/java.jdbc "0.2.3"]]
+  
+  :test-selectors {:default (fn [m] (not (:postgres m)))
+                   :all     (constantly true)}
+  
+  :jvm-opts ["-Dtest.database.url=postgresql://localhost:5432/enduro_test"])

--- a/src/alandipert/enduro/pgsql.clj
+++ b/src/alandipert/enduro/pgsql.clj
@@ -5,6 +5,9 @@
 (defn create-enduro-table! [table-name]
   (sql/create-table table-name [:id :int] [:value :text]))
 
+(defn delete-enduro-table! [table-name]
+  (sql/drop-table table-name))
+
 (defn table-exists? [table-name]
   (sql/with-query-results
     tables ["SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'"]
@@ -22,7 +25,10 @@
     (sql/with-connection db-config
       (sql/transaction
        (sql/update-or-insert-values
-        table-name ["id=?" 0] {:id 0 :value (pr-str value)})))))
+        table-name ["id=?" 0] {:id 0 :value (pr-str value)}))))
+  (-remove! [this]
+    (sql/with-connection db-config
+      (delete-enduro-table! table-name))))
 
 (defn postgresql-atom
   #=(e/with-options-doc "Creates and returns a PostgreSQL-backed atom. If the location

--- a/test/alandipert/enduro_test.clj
+++ b/test/alandipert/enduro_test.clj
@@ -1,7 +1,9 @@
 (ns alandipert.enduro-test
   (:use clojure.test)
   (:require [alandipert.enduro :as e]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [alandipert.enduro.pgsql :as pg]
+            [clojure.java.jdbc :as sql])
   (:import java.io.File
            java.util.concurrent.CountDownLatch))
 
@@ -10,6 +12,42 @@
 (defn tmp []
   (File/createTempFile "enduro" ".clj"))
 
+(def test-db-property "test.database.url")
+
+(def db-connection-err (str "This test requires that the " test-db-property " system property be a valid JDBC connection string. For example: 'postgresql://localhost:5432/your-db'"))
+
+(defn get-connection []
+  (if-let [database-url (System/getProperty test-db-property)]
+    (try (sql/with-connection database-url
+           database-url) 
+         (catch org.postgresql.util.PSQLException p
+           (throw (RuntimeException. db-connection-err p))))
+    (throw (RuntimeException. db-connection-err))))
+
+(defn some-random-table-name [] (str "test_enduro_" (rand-int (Integer/MAX_VALUE))))
+
+(defn pull-out-next-exception [outer]
+  (let [next  (.getNextException outer)
+        cause (.getCause outer)]
+    (cond
+     next (do (println (.getMessage outer)) (recur next))
+     cause (do (println (.getMessage outer)) (recur cause))
+     :else outer)))
+
+(defn call-with-sql-exception-unwrapping
+  "If JDBC gives us a BatchUpdateException, then the
+  real error message is deeper in and not displayed.
+  Drag it out of there."
+  [f]
+  (try
+    (f)
+    (catch java.sql.SQLException s
+      (throw (pull-out-next-exception s)))))
+
+(defmacro with-sql-exception-unwrapping
+  [& body]
+  `(call-with-sql-exception-unwrapping (fn [] ~@body)))
+
 (deftest initial-value
   (testing "initialization of file"
     (time
@@ -17,7 +55,7 @@
            ea (e/file-atom ["testing" 1 2 3] file :pending-dir "/tmp")]
        (is (= ["testing" 1 2 3] (e/read-file file)))))))
 
-(deftest writes
+(deftest write-file-atom
   (testing "concurrency of file atom"
     (time
      (let [file (tmp)
@@ -33,8 +71,14 @@
 
        (.await latch)
 
-       (is (= n (e/read-file file))))))
+       (is (= n (e/read-file file)))
+       
+       (testing "after release, attempting to read the atom should cause an exception"
+         (e/release! ea)
+         (is (thrown? AssertionError @ea))
+         (is (not (.exists file))))))))
 
+(deftest write-mem-atom
   (testing "concurrency of mem atom"
     (time
      (let [ea (e/mem-atom 0)
@@ -49,7 +93,58 @@
 
        (.await latch)
 
-       (is (= n @ea))))))
+       (is (= n @ea))
+
+       (testing "after release, attempting to read the atom should cause an exception"
+         (e/release! ea)
+         (is (thrown? AssertionError @ea)))))))
+
+(deftest ^:postgres postgres
+  (testing "concurrency of postgres atom"
+    (time
+     (let [connection-string (get-connection)
+           table-name (some-random-table-name)
+           n 100]
+       (let [ea (with-sql-exception-unwrapping (pg/postgresql-atom 0 connection-string table-name))
+             latch (CountDownLatch. n)]
+
+         (add-watch ea :x (fn [_ _ _ x] (.countDown latch)))
+
+         (dotimes [_ n]
+           (future
+             (e/swap! ea inc)))
+
+         (.await latch)
+
+         (is (= n @ea)))))))
+
+(deftest ^:postgres postgres-atom-semantics
+  (let [connection-string (get-connection)
+        table-name (some-random-table-name)]
+    
+    (testing "atom persistence across runs"
+      (let [some-value (rand-int 100)
+            ea-1 (with-sql-exception-unwrapping (pg/postgresql-atom some-value connection-string table-name))
+            ea-2 (with-sql-exception-unwrapping (pg/postgresql-atom 0 connection-string table-name))]
+        (is (= some-value @ea-1 @ea-2)
+            "all atoms initialized with the same table name should have the value previously stored in that table")
+        (with-sql-exception-unwrapping (e/release! ea-1))))
+
+    (testing "releasing an atom"
+      (let [ea (with-sql-exception-unwrapping (pg/postgresql-atom 0 connection-string table-name))]
+        (with-sql-exception-unwrapping (e/release! ea))
+        (is (thrown? AssertionError @ea) "attempting to access an atom after it's been released should raise an Assertionerror")
+        (sql/with-connection connection-string
+          (is (not (pg/table-exists? table-name)) "releasing a pg-backed atom should delete the table"))))
+
+    (testing "release and persistence across runs"
+      (let [first-value (rand-int 100)
+            second-value (rand-int 100)
+            ea-1 (with-sql-exception-unwrapping (pg/postgresql-atom first-value connection-string table-name))
+            _ (e/release! ea-1)
+            ea-2 (with-sql-exception-unwrapping (pg/postgresql-atom second-value connection-string table-name))]
+        (is (= second-value @ea-2) "the value of a released atom should not be persisted if a later atom is defined with the same table")
+        (with-sql-exception-unwrapping (e/release! ea-2))))))
 
 (deftest usage
   (testing "*print-length* unbound"


### PR DESCRIPTION
The release! interface was described in the README, but not implemented
in the code. We implemented it for all three backends, and added some
test coverage for the PostgreSQL backend.

With the PostgreSQL backend, release! causes the table backing the atom
to be dropped.

With the file backend, release! causes the file to be deleted.

With the memory backend, release! does nothing.

Attempting to read or write an atom after it has been released will
raise an exception, even for memory-backed atoms.

We added integration tests for the PostgreSQL backend, but disabled them
in the default test selector, since they require that the user set up a
suitable database beforehand. We added a new test selector, :all, to run
all tests including the Postgres integration tests. To run the tests,
the test.database.url system property will need to be set; we added a
:jvm-opts in the project.clj with an example value.

Authors:
Jessica Kerr
Tanya Romankova
Eli Naeher
Chris Freeman
